### PR TITLE
Adds transparent octet counting message framing

### DIFF
--- a/syslogssl.py
+++ b/syslogssl.py
@@ -14,7 +14,7 @@ class NewLineFraming:
     return message + '\n'
 
 
-class OctectCountingFraming:
+class OctetCountingFraming:
 
   def frame( self, message ):
     length = len( message )


### PR DESCRIPTION
This PR adds octet framing as per RFC 6587 3.4.1 and RFC 5425 4.3 allowing for messages up to at least 2048 and recommended up to 8192.